### PR TITLE
ci: ensure correct deployment checks in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 📦️ Install
         run: npm i
       - name: 🧪 Test and upload to Pactflow 📈
-        run: GIT_BRANCH=${GITHUB_REF:11} make ci
+        run: GIT_BRANCH=${GITHUB_REF:11} make test_and_publish
 
   # Runs on branches as well, so we know the status of our PRs
   can-i-deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,21 +23,21 @@ jobs:
       - name: 🧪 Test and upload to Pactflow 📈
         run: GIT_BRANCH=${GITHUB_REF:11} make ci
 
-  # Runs on branches as well, so we know the status of our PRs
-  can-i-deploy:
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - uses: actions/checkout@v3
-      - name: 🛂 Can I deploy?
-        run: GIT_BRANCH=${GITHUB_REF:11} make can_i_deploy
+  # # Runs on branches as well, so we know the status of our PRs
+  # can-i-deploy:
+  #   runs-on: ubuntu-latest
+  #   needs: [test]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: 🛂 Can I deploy?
+  #       run: GIT_BRANCH=${GITHUB_REF:11} make can_i_deploy
 
-  # Only deploy from master
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [can-i-deploy]
-    steps:
-      - uses: actions/checkout@v3
-      - name: 🚀 Deploy
-        run: GIT_BRANCH=${GITHUB_REF:11} make deploy
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+  # # Only deploy from master
+  # deploy:
+  #   runs-on: ubuntu-latest
+  #   needs: [can-i-deploy]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: 🚀 Deploy
+  #       run: GIT_BRANCH=${GITHUB_REF:11} make deploy
+  #       if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: 🚀 Deploy
         run: GIT_BRANCH=${GITHUB_REF:11} make deploy
-        # if: github.ref == 'refs/heads/main' # note this is set in our Makefile
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,23 +21,23 @@ jobs:
       - name: 📦️ Install
         run: npm i
       - name: 🧪 Test and upload to Pactflow 📈
-        run: GIT_BRANCH=${GITHUB_REF:11} make ci_full
+        run: GIT_BRANCH=${GITHUB_REF:11} make ci
 
-  # # Runs on branches as well, so we know the status of our PRs
-  # can-i-deploy:
-  #   runs-on: ubuntu-latest
-  #   needs: [test]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: 🛂 Can I deploy?
-  #       run: GIT_BRANCH=${GITHUB_REF:11} make can_i_deploy
+  # Runs on branches as well, so we know the status of our PRs
+  can-i-deploy:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🛂 Can I deploy?
+        run: GIT_BRANCH=${GITHUB_REF:11} make can_i_deploy
 
-  # # Only deploy from master
-  # deploy:
-  #   runs-on: ubuntu-latest
-  #   needs: [can-i-deploy]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: 🚀 Deploy
-  #       run: GIT_BRANCH=${GITHUB_REF:11} make deploy
-  #       if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+  # Only deploy from master
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [can-i-deploy]
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🚀 Deploy
+        run: GIT_BRANCH=${GITHUB_REF:11} make deploy
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 📦️ Install
         run: npm i
       - name: 🧪 Test and upload to Pactflow 📈
-        run: GIT_BRANCH=${GITHUB_REF:11} make ci
+        run: GIT_BRANCH=${GITHUB_REF:11} make ci_full
 
   # # Runs on branches as well, so we know the status of our PRs
   # can-i-deploy:

--- a/.github/workflows/test_pact_cli_tools_cross_os.yml
+++ b/.github/workflows/test_pact_cli_tools_cross_os.yml
@@ -99,3 +99,4 @@ jobs:
         run: make can_i_deploy
       - name: 🚀 Deploy
         run: make deploy
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'

--- a/.github/workflows/test_pact_cli_tools_cross_os.yml
+++ b/.github/workflows/test_pact_cli_tools_cross_os.yml
@@ -94,7 +94,7 @@ jobs:
       - name: 📦️ Install
         run: npm i
       - name: 🧪 Test and Publish Provider Contract to Pactflow 📈
-        run: make ci
+        run: make test_and_publish
       - name: 🛂 Can I deploy?
         run: make can_i_deploy
       - name: 🚀 Deploy

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,12 @@ all: test
 
 ci:
 	@if make test; then \
-		EXIT_CODE=0 make publish_and_deploy; \
+		EXIT_CODE=0 make ${CI_COMMAND}; \
 	else \
-		EXIT_CODE=1 make publish_and_deploy; \
+		EXIT_CODE=1 make ${CI_COMMAND}; \
 	fi; \
 
-publish_and_deploy: ${CI_COMMAND} can_i_deploy $(DEPLOY_TARGET)
+ci_full: ci can_i_deploy $(DEPLOY_TARGET)
 
 publish_provider_contract: .env
 	@echo "\n========== STAGE: publish provider contract (spec + results) ==========\n"
@@ -92,7 +92,7 @@ publish_provider_contract: .env
 # Run the ci target from a developer machine with the environment variables
 # set as if it was on Github Actions.
 # Use this for quick feedback when playing around with your workflows.
-fake_ci: .env ci
+fake_ci: .env ci_full
 
 ci_ruby_cli:
 	PACT_TOOL=ruby_cli make ci

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,12 @@ all: test
 
 ci:
 	@if make test; then \
-		EXIT_CODE=0 make ${CI_COMMAND}; \
+		EXIT_CODE=0 make publish_and_deploy; \
 	else \
-		EXIT_CODE=1 make ${CI_COMMAND}; \
+		EXIT_CODE=1 make publish_and_deploy; \
 	fi; \
+
+publish_and_deploy: ${CI_COMMAND} can_i_deploy $(DEPLOY_TARGET)
 
 publish_provider_contract: .env
 	@echo "\n========== STAGE: publish provider contract (spec + results) ==========\n"
@@ -90,10 +92,8 @@ publish_provider_contract: .env
 # Run the ci target from a developer machine with the environment variables
 # set as if it was on Github Actions.
 # Use this for quick feedback when playing around with your workflows.
-fake_ci: .env
-	make ci; 
-	make deploy_target
-	
+fake_ci: .env ci
+
 ci_ruby_cli:
 	PACT_TOOL=ruby_cli make ci
 

--- a/Makefile
+++ b/Makefile
@@ -67,14 +67,14 @@ all: test
 ## CI tasks
 ## ====================
 
-ci:
+ci: .env test_and_publish can_i_deploy $(DEPLOY_TARGET)
+
+test_and_publish:
 	@if make test; then \
 		EXIT_CODE=0 make ${CI_COMMAND}; \
 	else \
 		EXIT_CODE=1 make ${CI_COMMAND}; \
 	fi; \
-
-ci_full: ci can_i_deploy $(DEPLOY_TARGET)
 
 publish_provider_contract: .env
 	@echo "\n========== STAGE: publish provider contract (spec + results) ==========\n"
@@ -92,7 +92,7 @@ publish_provider_contract: .env
 # Run the ci target from a developer machine with the environment variables
 # set as if it was on Github Actions.
 # Use this for quick feedback when playing around with your workflows.
-fake_ci: .env ci_full
+fake_ci: .env ci
 
 ci_ruby_cli:
 	PACT_TOOL=ruby_cli make ci


### PR DESCRIPTION
When the GH actions builds were created, they were split into 3 steps (test/upload, can-i-deploy, deploy)

This isn't compatible with the current Makefile setup and leads to 

1. GitHub actions builds are deploying to production on every branch, as the `make deploy` command, doesn't use the `$(DEPLOY_TARGET)` makefile command
2. `make fake_ci` is not calling `can_i_deploy` before calling `make deploy_target`

This adds

1. a full CI workflow `make ci: .env test_and_publish can_i_deploy $(DEPLOY_TARGET)`
2. uses test_and_publish / can_i_deploy & deploy as separate steps in the CI demo via GitHub actions, but with an if condition on deploy (to check for main/master branch)

NB:- the `make fake_ci` command is possibly superfluous now, as the env vars it used to set (GIT_COMMIT/GIT_BRANCH) are defaulted, if not already set